### PR TITLE
Tiny fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You should then be able to build and run Tokaido in Xcode.
 Compiling static ruby:
 
     curl -L https://raw.github.com/sm/sm/master/bin/sm-installer | sh
-    echo "export PATH=\"$HOME/.sm/bin:$HOME/.sm/pkg/active/bin:\$PATH\"" >> .bashrc
+    echo "export PATH=\"$HOME/.sm/bin:$HOME/.sm/pkg/active/bin:\$PATH\"" >> ~/.bashrc
     source ~/.bashrc
     sm ext install tokaidoapp tokaido/tokaidoapp
     sm tokaidoapp dependencies


### PR DESCRIPTION
You have .bashrc instead of ~/.bashrc in the static compilation instructions!
