### PR TITLE
Add "bundle install" to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ When first cloning this repo, be sure to run the following:
 
     gem install cocoapods
     pod install
+    bundle install
     rake
     open Tokaido.xcworkspace
 


### PR DESCRIPTION
So I can just copy and paste the instructions. When I tried with the current instructions I was missing a gem.
