### PR TITLE
Removes collateral CPU intensive use

### DIFF
--- a/Tokaido/TKDTask.h
+++ b/Tokaido/TKDTask.h
@@ -44,5 +44,5 @@ typedef NS_ENUM(NSInteger, TKDTaskState) {
 @property (nonatomic, readonly) NSArray *standardErrorLines;
 
 - (void)launch;
-
+- (void)waitUntilExit;
 @end


### PR DESCRIPTION
As soon as you add an app (it doesn't matter what it is) and click "Boot app". Wether it works or not (the bundle installation task) the application starts doing system calls massively with no signs of stoping it.

My guess is that it has something to do with the reading from the pipes. It used blocks everywhere, references everywhere, delegates, really hard to tell.

This pull request generates and does the reading from the subprocess _from another thread_.
